### PR TITLE
Update utils.py

### DIFF
--- a/gcovr/utils.py
+++ b/gcovr/utils.py
@@ -217,7 +217,11 @@ class RelativeFilter(Filter):
 
     def match(self, path):
         abspath = os.path.realpath(path)
-        relpath = os.path.relpath(abspath, self.root)
+        try:
+            relpath = os.path.relpath(abspath, self.root)
+        except ValueError:
+            # In Windows no relative path exists across drive letters
+            return None
         return super(RelativeFilter, self).match(relpath)
 
     def __str__(self):


### PR DESCRIPTION
Workaround for #320.
Catch path error created in windows when filer/exclude is enabled and some source files are on the other drive letter.